### PR TITLE
Add coercion from RleList to RleArray

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: Wrapping an array-like object (typically an on-disk object) in
 	also works on in-memory array-like objects like DataFrame objects
 	(typically with Rle columns), Matrix objects, and ordinary arrays and
 	data frames.
-Version: 0.5.1
+Version: 0.5.2
 Encoding: UTF-8
 Author: Hervé Pagès
 Maintainer: Hervé Pagès <hpages@fredhutch.org>

--- a/R/RleArray-class.R
+++ b/R/RleArray-class.R
@@ -210,6 +210,22 @@ setAs("RleRealizationSink", "Rle",
     }
 )
 
+setAs("RleList", "RleArray",
+    function(from)
+    {
+        from_lens <- lengths(from, use.names = FALSE)
+        if (identical(from_lens, integer(0L))) {
+            return(RleArray(unlist(from), c(0L, 0L)))
+        }
+        e1_len <- from_lens[1L]
+        if (any(from_lens != e1_len)) {
+          stop("All elements of RleList must have the same length")
+        }
+        RleArray(unlist(from, use.names = FALSE),
+                 c(e1_len, length(from)),
+                 list(NULL, names(from)))
+    }
+)
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ### subset_seed_as_array()

--- a/inst/unitTests/test_RleArray-class.R
+++ b/inst/unitTests/test_RleArray-class.R
@@ -43,3 +43,13 @@ test_long_RleArray <- function()
     ## TODO: Add more tests...
 }
 
+test_coercion_to_RleArray <- function() {
+    from <- RleList()
+    checkIdentical(as(from, "RleArray"), RleArray(Rle(), c(0, 0)))
+    from <- RleList(A = Rle(1, 10), B = Rle(2, 10))
+    checkIdentical(as(from, "RleArray"),
+                   RleArray(Rle(c(1, 2), c(10, 10)), c(10, 2),
+                            list(NULL, c("A", "B"))))
+    from <- RleList(A = Rle(1, 10), B = Rle(2, 9))
+    checkException(as(from, "RleArray"), silent = TRUE)
+}

--- a/man/RleArray-class.Rd
+++ b/man/RleArray-class.Rd
@@ -32,6 +32,7 @@
 \alias{coerce,RleArray,RleMatrix-method}
 \alias{matrixClass,RleArray-method}
 \alias{coerce,ANY,RleMatrix-method}
+\alias{coerce,RleArray,RleList-method}
 
 \alias{DelayedArray,RleArraySeed-method}
 \alias{RleArray}
@@ -135,6 +136,13 @@ stopifnot(identical(cs, CS))
 ## Coercion of a DelayedMatrix object to DataFrame produces a DataFrame
 ## object with Rle columns:
 as(B, "DataFrame")
+
+## Coercion of an RleList to an RleArray. Only works if each element of the
+## RleList has the same length. Column names are taken from the names of the
+## list elements
+rle_list <- RleList(A = Rle(sample(3, 100, replace = TRUE)),
+                    B = Rle(sample(3, 100, replace = TRUE)))
+rle_array <- as(rle_list, "RleArray")
 }
 \keyword{methods}
 \keyword{classes}


### PR DESCRIPTION
Motivated by https://support.bioconductor.org/p/102599/. I've had a similar need when trying to create a matrix-like object from coverage vectors (rows as positions, columns as samples) to stick in a SummarizedExperiment.