### PR TITLE
More unit tests and streamlined matrix multiplication

### DIFF
--- a/R/DelayedMatrix-utils.R
+++ b/R/DelayedMatrix-utils.R
@@ -232,7 +232,7 @@ setMethod("%*%", c("DelayedMatrix", "DelayedMatrix"), .BLOCK_matrix_mult)
 # If the block size is too large, it is reduced to obtain the desired
 # number of blocks in order for parallelization to be effective.
 {
-    old <- getAutoBlockSize()
+    old <- getAutoBlockLength(type(x))
 
     ideal_size_by_row <- max(1, ceiling(nrow(x)/nworkers) * ncol(x))
     if (old > ideal_size_by_row) {

--- a/R/DelayedMatrix-utils.R
+++ b/R/DelayedMatrix-utils.R
@@ -217,250 +217,6 @@ setMethod("%*%", c("DelayedMatrix", "ANY"),
 
 setMethod("%*%", c("DelayedMatrix", "DelayedMatrix"), .BLOCK_matrix_mult)
 
-
-### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-### Costing calculations for parallelized multiplication
-###
-### by Aaron Lun
-###
-### We make some careful decisions about how to parallelize %*% operations.
-### This is done to minimize the redundant data processing, especially when
-### chunks of data can only be read in an atomic manner.
-###
-
-.define_atomic_chunks <- function(x)
-# Defines atomic chunks across rows or columns of 'x'. These are subsets of
-# contiguous rows or columns that must be read in their entirety. Wholly
-# in-memory matrices have trivial boundaries, i.e., per row/column. Chunks
-# for HDF5 matrices are defined by the physical layout.
-{
-    grid <- chunkGrid(x)
-    if (is.null(grid)) {
-        row_out <- list(
-            bound=seq_len(nrow(x)),
-            size=rep(1L, nrow(x))
-        )
-        row_out$cost <- row_out$size
-
-        col_out <- list(
-            bound=seq_len(ncol(x)),
-            size=rep(1L, ncol(x))
-        )
-        col_out$cost <- col_out$size
-
-    } else {
-        N <- dim(grid)
-        bygrid <- dims(grid)
-
-        row_dims <- bygrid[seq_len(N[1]),1]
-        row_out <- list(
-            bound=cumsum(row_dims),
-            size=row_dims
-        )
-        # file-backed penalty (relative to 1).
-        # TODO: accommodate penalties for combined seeds that are only partially file-backed.
-        row_out$cost <- row_out$size * 10L
-
-        col_dims <- bygrid[seq_len(N[2]) * N[1],2]
-        col_out <- list(
-            bound=cumsum(col_dims),
-            size=col_dims
-        )
-        col_out$cost <- col_out$size * 10L
-    }
-
-    list(row=row_out, col=col_out)
-}
-
-.grid_by_dimension <- function(x, nworkers)
-# Splits a dimension of the matrix into at least 'nworkers' blocks.
-# If the block size is too large, it is reduced to obtain the desired
-# number of blocks in order for parallelization to be effective.
-{
-    old <- getAutoBlockSize()
-    element_size <- switch(type(x), double=8, 4)
-
-    ideal_size_by_row <- max(1, ceiling(nrow(x)/nworkers) * as.double(ncol(x)) * element_size)
-    if (old > ideal_size_by_row) {
-        suppressMessages(setAutoBlockSize(ideal_size_by_row)) # TODO: avoid setting the block size just to compute this?
-        row_grid <- rowAutoGrid(x)
-        suppressMessages(setAutoBlockSize(old))
-    } else {
-        row_grid <- rowAutoGrid(x)
-    }
-
-    ideal_size_by_col <- max(1, ceiling(ncol(x)/nworkers) * as.double(nrow(x)) * 8)
-    if (old > ideal_size_by_col) {
-        suppressMessages(setAutoBlockSize(ideal_size_by_col))
-        col_grid <- colAutoGrid(x)
-        suppressMessages(setAutoBlockSize(old))
-    } else {
-        col_grid <- colAutoGrid(x)
-    }
-
-    list(row=row_grid, col=col_grid)
-}
-
-.evaluate_split_costs <- function(split, dim_info)
-# Given a split of a matrix dimension into putative blocks, 
-# evaluate the costs with respect to chunk atomicity.
-{
-    boundaries <- dim_info$bound
-    if (length(boundaries)==0L) { return(0) } # avoid NAs from zero-length dim.
-    chunk_cost <- dim_info$cost
-
-    right_chunk_index <- findInterval(split, boundaries, left.open=TRUE) + 1L
-    block_starts <- c(1L, head(split, -1L) + 1L)
-    left_chunk_index <- findInterval(block_starts, boundaries, left.open=TRUE) + 1L
-
-    cum_cost <- c(0L, cumsum(chunk_cost))
-    cum_cost[right_chunk_index+1L] - cum_cost[left_chunk_index]
-}
-
-.dispatch_mult <- function(x, y, nworkers, transposed.x=FALSE, transposed.y=FALSE)
-# Decides how to split jobs across multiple workers for x %*% y
-# or equivalent operations involving their transposes.
-{
-    atomic_x <- .define_atomic_chunks(x)
-    nr_x <- as.double(nrow(x)) # use double to avoid overflow.
-    nc_x <- as.double(ncol(x))
-
-    atomic_y <- .define_atomic_chunks(y)
-    nr_y <- as.double(nrow(y))
-    nc_y <- as.double(ncol(y))
-
-    x_grids <- .grid_by_dimension(x, nworkers)
-    y_grids <- .grid_by_dimension(y, nworkers)
-
-    # Mimicking the effect of supplying t(x) or t(y) (without actually computing them).
-    if (transposed.x) {
-        atomic_x <- list(row=atomic_x$col, col=atomic_x$row)
-        x_grids <- list(row=t(x_grids$col), col=t(x_grids$row))
-        tmp <- nr_x
-        nr_x <- nc_x
-        nc_x <- tmp
-    }
-
-    if (transposed.y) {
-        atomic_y <- list(row=atomic_y$col, col=atomic_y$row)
-        y_grids <- list(row=t(y_grids$col), col=t(y_grids$row))
-        tmp <- nr_y
-        nr_y <- nc_y
-        nc_y <- tmp
-    }
-
-    # Determining costs for each job splitting scheme.
-    # Assessment is based on the maximum cost for a given worker under each scheme,
-    # with the aim being to minimize the maximum time to complete all jobs.
-    x_by_row <- cumsum(dims(x_grids$row)[,1])
-    x_by_row_cost <- .evaluate_split_costs(x_by_row, atomic_x$row)
-    x_by_col <- cumsum(dims(x_grids$col)[,2])
-
-    y_by_row <- cumsum(dims(y_grids$row)[,1])
-    y_by_col <- cumsum(dims(y_grids$col)[,2])
-    y_by_col_cost <- .evaluate_split_costs(y_by_col, atomic_y$col)
-
-    cost_x_by_row <- max(x_by_row_cost * nc_x) + nr_y * sum(y_by_col_cost)
-    cost_y_by_col <- sum(x_by_row_cost) * nc_x + max(nr_y * y_by_col_cost)
-
-    if (getAutoMultParallelAgnostic()) { 
-        # Ignoring splitting by the common dimension, as this is not
-        # agnostic with respect to the number of workers.
-        all_options <- c(x_by_row=cost_x_by_row, y_by_col=cost_y_by_col)
-            
-    } else {
-        cost_common_x <- max(
-            nr_x * .evaluate_split_costs(x_by_col, atomic_x$col) +
-            .evaluate_split_costs(x_by_col, atomic_y$row) * nc_y
-        )
-        cost_common_y <- max(
-            nr_x * .evaluate_split_costs(y_by_row, atomic_x$col) +
-            .evaluate_split_costs(y_by_row, atomic_y$row) * nc_y
-        )
-
-        all_options <- c(x_by_row=cost_x_by_row, y_by_col=cost_y_by_col, common_x=cost_common_x, common_y=cost_common_y)
-    } 
-
-    choice <- names(all_options)[which.min(all_options)]
-
-    if (choice=="x_by_row" || choice=="y_by_col") {
-        # Both are returned though only one is used at any given time;
-        # see .super_BLOCK_mult() for why we need both available.
-        grid <- list(x=x_grids$row, y=y_grids$col)
-
-    } else if (choice=="common_x") {
-        grid <- list(x=x_grids$col,
-            y=ArbitraryArrayGrid(list(
-                cumsum(dims(x_grids$col)[,2]),
-                as.integer(nc_y)
-            ))
-        )
-    } else {
-        grid <- list(
-            x=ArbitraryArrayGrid(list(
-                as.integer(nr_x),
-                cumsum(dims(y_grids$row)[,1])
-            )),
-            y=y_grids$row)
-    }
-
-    # Undo the transposition to get viewports for the original matrix.
-    if (transposed.x) {
-        grid$x <- t(grid$x)
-    }
-    if (transposed.y) {
-        grid$y <- t(grid$y)
-    }
-    choice <- switch(choice, x_by_row="x", y_by_col="y", common_x="common", common_y="common")
-    list(choice=choice, grid=grid)
-}
-
-.dispatch_self <- function(x, nworkers, transposed=FALSE)
-# Decides how to split jobs across multiple workers for crossprod(x).
-{
-    atomic <- .define_atomic_chunks(x)
-    nr <- as.double(nrow(x)) # use double to avoid overflow.
-    nc <- as.double(ncol(x))
-    grids <- .grid_by_dimension(x, nworkers)
-
-    if (transposed) {
-        atomic <- list(row=atomic$col, col=atomic$row)
-        grids <- list(row=t(grids$col), col=t(grids$row))
-        tmp <- nr
-        nr <- nc
-        nc <- tmp
-    }
-
-    if (getAutoMultParallelAgnostic()) {
-        choice <- "single"
-        grid <- grids$col
-
-    } else {
-        # Splitting 'x' by column, and taking the crossproduct with all of 'x'.
-        # This is the same the other way around, so we don't bother computing that.
-        by_col <- cumsum(dims(grids$col)[,2])
-        by_col_cost <- .evaluate_split_costs(by_col, atomic$col)
-        cost_single <- max(nr * by_col_cost) + nr * sum(by_col_cost)
-    
-        # Splitting by the common dimension, i.e., along the rows of 'x'
-        # and taking the crossproduct of each split block.
-        by_row <- cumsum(dims(grids$row)[,1])
-        by_row_cost <- .evaluate_split_costs(by_row, atomic$row)
-        cost_both <- max(by_row_cost * nc)
-    
-        all_options <- c(both=cost_both, single=cost_single)
-        choice <- names(all_options)[which.min(all_options)]
-        grid <- switch(choice, both=grids$row, single=grids$col)
-    }
-
-    # Obtaining the grid for the original 'x'.
-    if (transposed) {
-        grid <- t(grid)
-    }
-    list(choice=choice, grid=grid)
-}
-
-
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ### Parallelized schemes for matrix multiplication.
 ###
@@ -471,97 +227,104 @@ setMethod("%*%", c("DelayedMatrix", "DelayedMatrix"), .BLOCK_matrix_mult)
 ### This also requires care to respect the maximum block size.
 ###
 
-.single_grid_iterate <- function(grid) {
-    force(grid)
-    bid <- 0L
+.grid_by_dimension <- function(x, nworkers)
+# Splits a dimension of the matrix into at least 'nworkers' blocks.
+# If the block size is too large, it is reduced to obtain the desired
+# number of blocks in order for parallelization to be effective.
+{
+    old <- getAutoBlockSize()
 
-    # Do NOT put read_block in here, as this will waste time realizing from file in the single worker.
-    # TODO: subset in-memory matrices to avoid serializing them in their entirety to the workers.
-    function () {
-        if (bid == length(grid)) return(NULL)
-        bid <<- bid + 1L
-        grid[[bid]]
+    ideal_size_by_row <- max(1, ceiling(nrow(x)/nworkers) * ncol(x))
+    if (old > ideal_size_by_row) {
+        row_grid <- rowAutoGrid(x, block.length=ideal_size_by_row)
+    } else {
+        row_grid <- rowAutoGrid(x)
     }
+
+    ideal_size_by_col <- max(1, ceiling(ncol(x)/nworkers) * nrow(x))
+    if (old > ideal_size_by_col) {
+        col_grid <- colAutoGrid(x, block.length=ideal_size_by_col)
+    } else {
+        col_grid <- colAutoGrid(x)
+    }
+
+    list(row=row_grid, col=col_grid)
 }
 
-.left_mult <- function(viewport, x, y, MULT) {
-    block <- .read_matrix_block(x, viewport) # this, and all other calls, had better yield a non-DA, otherwise MULT will recurse endlessly.
+.left_mult <- function(bid, grid, x, y, MULT) {
+    # this, and all other calls, had better yield a non-DA, otherwise MULT will recurse endlessly.
+    block <- .read_matrix_block(x, grid[[bid]]) 
     MULT(block, y)
 }
 
-.right_mult <- function(viewport, x, y, MULT) {
-    block <- .read_matrix_block(y, viewport)
+.right_mult <- function(bid, grid, x, y, MULT) {
+    block <- .read_matrix_block(y, grid[[bid]])
     MULT(x, block)
-}
-
-.dual_grid_iterate <- function(grid.x, grid.y) {
-    force(grid.x)
-    force(grid.y)
-    bid <- 0L
-
-    function () {
-        if (bid == length(grid.x)) return(NULL)
-        bid <<- bid + 1L
-        list(x=grid.x[[bid]], y=grid.y[[bid]])
-    }
-}
-
-.both_mult <- function(viewports, x, y, MULT) {
-    block_x <- .read_matrix_block(x, viewports$x)
-    block_y <- .read_matrix_block(y, viewports$y)
-    MULT(block_x, block_y)
 }
 
 .super_BLOCK_mult <- function(x, y, MULT, transposed.x=FALSE, transposed.y=FALSE, BPPARAM=getAutoBPPARAM())
 # Controller function that split jobs for a multiplication function "MULT".
 # This accommodates %*%, crossprod and tcrossprod for two arguments.
 {
-    if (!requireNamespace("BiocParallel", quietly=TRUE))
-        stop(wmsg("Couldn't load the BiocParallel package. Please ",
-                  "install the BiocParallel package and try again."))
-    if (is.null(BPPARAM))
-        BPPARAM <- BiocParallel::SerialParam()
-    nworkers <- BiocParallel::bpnworkers(BPPARAM)
-    scheme_out <- .dispatch_mult(x, y, nworkers, transposed.x=transposed.x, transposed.y=transposed.y)
-    chosen_scheme <- scheme_out$choice
-    chosen_grids <- scheme_out$grid
+    if (is.null(BPPARAM)) {
+        nworkers <- 1L
+    } else {
+        nworkers <- BiocParallel::bpnworkers(BPPARAM)
+    }
+
+    # Choosing the right dimension to iterate over, depending on MULT.
+    x_grid <- .grid_by_dimension(x, nworkers)
+    if (transposed.x) {
+        x_grid <- x_grid$col
+    } else {
+        x_grid <- x_grid$row
+    }
+
+    y_grid <- .grid_by_dimension(y, nworkers)
+    if (transposed.y) {
+        y_grid <- y_grid$row
+    } else {
+        y_grid <- y_grid$col
+    }
+
+    # Always iterating over the 'larger' matrix, to better split up the work.
+    # In the context of file-backed matrices, this operates under the heuristic
+    # that the larger matrix is the file-backed one.
+    if (length(x) > length(y)) {
+        chosen_scheme <- "x"
+    } else {
+        chosen_scheme <- "y"
+    }
+
+    # Switch to iteration over the other argument if the chosen one is
+    # single-block and non-DA (at which point you might as well iterate
+    # over the other argument anyway). This avoids infinite recursion
+    # when 'x' or 'y' fail to get realized via read_block().
+    if (chosen_scheme=="x" && length(x_grid)==1L && !is(x, "DelayedMatrix")) {
+        chosen_scheme <- "y"
+    } else if (chosen_scheme=="y" && length(y_grid)==1L && !is(y, "DelayedMatrix")) {
+        chosen_scheme <- "x"
+    }
 
     old <- getAutoBPPARAM()
     on.exit(setAutoBPPARAM(old))
     ## Avoid re-parallelizing in further calls to 'MULT'.
     setAutoBPPARAM(BiocParallel::SerialParam())
 
-    if (chosen_scheme=="common") {
-        ITER <- .dual_grid_iterate(chosen_grids$x, chosen_grids$y)
-        ans <- BiocParallel::bpiterate(ITER,
-                                       FUN=.both_mult, x=x, y=y, MULT=MULT,
-                                       BPPARAM=BPPARAM,
-                                       REDUCE=function(x, y) x + y)
-
-    } else {
-        # Switch to iteration over the other argument if the chosen one is
-        # single-block and non-DA (at which point you might as well iterate
-        # over the other argument anyway). This avoids infinite recursion
-        # when 'x' or 'y' fail to get realized via read_block().
-        if (chosen_scheme=="x" && length(chosen_grids$x)==1L && !is(x, "DelayedMatrix")) {
-            chosen_scheme <- "y"
-        } else if (chosen_scheme=="y" && length(chosen_grids$y)==1L && !is(y, "DelayedMatrix")) {
-            chosen_scheme <- "x"
-        }
-
-        if (chosen_scheme=="x") {
-            ITER <- .single_grid_iterate(chosen_grids$x)
-            out <- BiocParallel::bpiterate(ITER,
-                                           FUN=.left_mult, x=x, y=y, MULT=MULT,
-                                           BPPARAM=BPPARAM)
-            ans <- do.call(rbind, out)
-        } else if (chosen_scheme=="y") {
-           ITER <- .single_grid_iterate(chosen_grids$y)
-           out <- BiocParallel::bpiterate(ITER,
-                                          FUN=.right_mult, x=x, y=y, MULT=MULT,
-                                          BPPARAM=BPPARAM)
-           ans <- do.call(cbind, out)
-        }
+    if (chosen_scheme=="x") {
+        out <- bplapply2(seq_len(length(x_grid)),
+                         FUN=.left_mult, 
+                         x=x, y=y, grid=x_grid, 
+                         MULT=MULT, 
+                         BPPARAM=BPPARAM)
+        ans <- do.call(rbind, out)
+    } else if (chosen_scheme=="y") {
+        out <- bplapply2(seq_len(length(y_grid)),
+                         FUN=.right_mult, 
+                         x=x, y=y, grid=y_grid, 
+                         MULT=MULT, 
+                         BPPARAM=BPPARAM)
+        ans <- do.call(cbind, out)
     }
 
     realize(ans)
@@ -589,20 +352,26 @@ setMethod("crossprod", c("ANY", "DelayedMatrix"), function(x, y) {
     .super_BLOCK_mult(x, y, MULT=crossprod, transposed.x=TRUE)
 })
 
-setMethod("crossprod", c("DelayedMatrix", "DelayedMatrix"), function(x, y) .super_BLOCK_mult(x, y, MULT=crossprod, transposed.x=TRUE))
+setMethod("crossprod", c("DelayedMatrix", "DelayedMatrix"), function(x, y) 
+    .super_BLOCK_mult(x, y, MULT=crossprod, transposed.x=TRUE)
+)
 
 # tcrossprod with vector 'y' doesn't work in base, and so it won't work here either.
-setMethod("tcrossprod", c("DelayedMatrix", "ANY"), function(x, y) .super_BLOCK_mult(x, y, MULT=tcrossprod, transposed.y=TRUE))
+setMethod("tcrossprod", c("DelayedMatrix", "ANY"), function(x, y) 
+    .super_BLOCK_mult(x, y, MULT=tcrossprod, transposed.y=TRUE)
+)
 
 setMethod("tcrossprod", c("ANY", "DelayedMatrix"), function(x, y) {
     if (is.null(dim(x))) x <- rbind(x)
     .super_BLOCK_mult(x, y, MULT=tcrossprod, transposed.y=TRUE)
 })
 
-setMethod("tcrossprod", c("DelayedMatrix", "DelayedMatrix"), function(x, y) .super_BLOCK_mult(x, y, MULT=tcrossprod, transposed.y=TRUE))
+setMethod("tcrossprod", c("DelayedMatrix", "DelayedMatrix"), function(x, y) 
+    .super_BLOCK_mult(x, y, MULT=tcrossprod, transposed.y=TRUE)
+)
 
-.solo_mult <- function(viewport, x, MULT) {
-    block <- read_block(x, viewport)
+.solo_mult <- function(bid, grid, x, MULT) {
+    block <- read_block(x, grid[[bid]])
     MULT(block)
 }
 
@@ -610,43 +379,54 @@ setMethod("tcrossprod", c("DelayedMatrix", "DelayedMatrix"), function(x, y) .sup
 # Controller function that split jobs for a multiplication function "MULT".
 # This accommodates crossprod and tcrossprod for single arguments.
 {
-    if (!requireNamespace("BiocParallel", quietly=TRUE))
-        stop(wmsg("Couldn't load the BiocParallel package. Please ",
-                  "install the BiocParallel package and try again."))
-    if (is.null(BPPARAM))
-        BPPARAM <- BiocParallel::SerialParam()
-    nworkers <- BiocParallel::bpnworkers(BPPARAM)
-    scheme_out <- .dispatch_self(x, nworkers, transposed=transposed)
-    chosen_scheme <- scheme_out$choice
-    chosen_grids <- scheme_out$grid
+    if (is.null(BPPARAM)) {
+        nworkers <- 1L
+    } else {
+        nworkers <- BiocParallel::bpnworkers(BPPARAM)
+    }
+
+    # Choosing the right dimension to iterate over, depending on MULT.
+    grid <- .grid_by_dimension(x, nworkers)
+    if (transposed) {
+        fast <- grid$col
+        slow <- grid$row
+    } else {
+        fast <- grid$row
+        slow <- grid$col
+    }
 
     old <- getAutoBPPARAM()
     on.exit(setAutoBPPARAM(old))
     ## Avoid re-parallelizing in further calls to 'MULT'.
     setAutoBPPARAM(BiocParallel::SerialParam())
 
-    if (chosen_scheme=="single") {
-        ITER <- .single_grid_iterate(chosen_grids)
-        out <- BiocParallel::bpiterate(ITER,
-                                       FUN=.left_mult, x=x, y=x, MULT=MULT,
-                                       BPPARAM=BiocParallel::SerialParam())
+    if (getAutoMultParallelAgnostic()) {
+        out <- bplapply2(seq_len(length(slow)),
+                         FUN=.left_mult, 
+                         x=x, y=x, grid=slow,
+                         MULT=MULT,
+                         BPPARAM=BiocParallel::SerialParam())
         ans <- do.call(rbind, out)
 
-    } else if (chosen_scheme=="both") {
-        ITER <- .single_grid_iterate(chosen_grids)
-        ans <- BiocParallel::bpiterate(ITER,
-                                       FUN=.solo_mult, x=x, MULT=MULT,
-                                       BPPARAM=BPPARAM,
-                                       REDUCE=function(x, y) x+y)
-
+    } else {
+        ans <- bplapply2(seq_len(length(fast)),
+                         FUN=.solo_mult,
+                         x=x, grid=fast,
+                         MULT=MULT,
+                         BPPARAM=BPPARAM)
+        ans <- Reduce("+", ans)
     }
 
     realize(ans)
 }
 
-setMethod("crossprod", c("DelayedMatrix", "missing"), function(x, y) .super_BLOCK_self(x, MULT=crossprod))
+setMethod("crossprod", c("DelayedMatrix", "missing"), function(x, y) 
+    .super_BLOCK_self(x, MULT=crossprod)
+)
 
-setMethod("tcrossprod", c("DelayedMatrix", "missing"), function(x, y) .super_BLOCK_self(x, MULT=tcrossprod, transposed=TRUE))
+setMethod("tcrossprod", c("DelayedMatrix", "missing"), function(x, y) 
+    .super_BLOCK_self(x, MULT=tcrossprod, transposed=TRUE)
+)
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ### User-visible global settings for parallelized matrix multiplication.


### PR DESCRIPTION
The general problem of capturing error messages in a `cbind` has been solved by switching from `bpiterate` to `bplapply2`, so now errors inside the matrix multiplication lead to errors in the parent process. This has the additional bonus of not requiring **BiocParallel** to be installed to do matrix multiplication.

I also greatly streamlined the decision-making process of choosing the iteration scheme in the matrix multiplication. Now it just prioritizes the larger matrix as the one to split up for distributed computation across workers. This is not really any worse than the previous approach, which relied on the presence of a non-`NULL` return from `chunkGrid` as a heuristic to identify which matrix was more likely to be file-backed... and then added an arbitrary penalty of 10 to the access cost of the chunks of that matrix. The new approach is very simple and easy to reason about.

The streamlining was also assisted by the realization that `getAutoMultParallelAgnostic()` was never actually exported. No users should have been able to use the non-agnostic matrix multiplication scheme, so I just got rid of it in the general case to make maintenance easier. I retained the non-agnostic option for self-cross-products due to its clear performance advantage though the default is still to use the agnostic mode for consistency with `%*%`.

(I don't know what the future plans for the matrix multiplication algorithm will be, but being able to achieve consistent results that are agnostic to the number of workers, block size and chunk dimensions is very logistically useful. I know that there will be situations where an agnostic algorithm just won't cut it, e.g., due to chunk or block size constraints, and we may need a different algorithm in such cases; but having agnosticism as the default, where possible, really makes it easy to scale things up and down while still getting the same results.) 

Finally, I enhanced the battery of unit tests.