### PR TITLE
Preserve sparsity in IsoOpWithArgs.

### DIFF
--- a/R/DelayedOp-class.R
+++ b/R/DelayedOp-class.R
@@ -666,20 +666,23 @@ setMethod("extract_array", "DelayedUnaryIsoOpWithArgs",
 ### case) and no zero or NA or NaN values (in the division case).
 
 setMethod("is_sparse", "DelayedUnaryIsoOpWithArgs", function(x) {
-    if (identical(x@OP, `*`)) {
-        for (v in c(x@Largs, x@Rargs)) {
-            if (any(!is.finite(v))) {
-                return(FALSE)
+    if (is_sparse(seed(x))) {
+        if (identical(x@OP, `*`)) {
+            for (v in c(x@Largs, x@Rargs)) {
+                if (any(!is.finite(v))) {
+                    return(FALSE)
+                }
             }
-        }
-        return(TRUE)
-    } else if (identical(x@OP, `/`)) {
-        for (v in c(x@Largs, x@Rargs)) {
-            if (any(!is.finite(v) | v==0)) {
-                return(FALSE)
+            return(TRUE)
+
+        } else if (identical(x@OP, `/`)) {
+            for (v in c(x@Largs, x@Rargs)) {
+                if (any(!is.finite(v) | v==0)) {
+                    return(FALSE)
+                }
             }
+            return(TRUE)
         }
-        return(TRUE)
     }
 
     FALSE


### PR DESCRIPTION
Closes #73:

```r
library(DelayedArray)
library(Matrix)
mat <- rsparsematrix(1000, 1000, 0.01)
div <- runif(nrow(mat))
is_sparse(mat/div)
## [1] TRUE

out <- DelayedArray(mat)
is_sparse(out)
## [1] TRUE

out2 <- out / div
is_sparse(out2)
## [1] TRUE

ref <- as(out2, "dgCMatrix")
identical(ref, mat/div)
## [1] TRUE
```

If this looks good, happy to throw in some tests.