### PR TITLE
Adding a ConstantArray class

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,4 +68,6 @@ Collate: utils.R
 	DelayedMatrix-stats.R
 	RleArraySeed-class.R
 	RleArray-class.R
+    ConstantArraySeed-class.R
+    ConstantArray-class.R
 	zzz.R

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -324,7 +324,8 @@ export(
     RleArray,
 
     ## ConstantArray-class.R:
-    ConstantArray
+    ConstantArray,
+    ConstantArraySeed
 )
 
 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -72,7 +72,11 @@ exportClasses(
 
     ## RleArray-class.R:
     RleArraySeed, SolidRleArraySeed, RleRealizationSink, ChunkedRleArraySeed,
-    RleArray, RleMatrix
+    RleArray, RleMatrix,
+
+    ## ConstantArray-class.R:
+    ConstantArraySeed, 
+    ConstantArray, ConstantMatrix
 )
 
 
@@ -317,7 +321,10 @@ export(
     BLOCK_write_to_sink,
 
     ## RleArray-class.R:
-    RleArray
+    RleArray,
+
+    ## ConstantArray-class.R:
+    ConstantArray
 )
 
 

--- a/R/ConstantArray-class.R
+++ b/R/ConstantArray-class.R
@@ -10,7 +10,7 @@ setClass("ConstantMatrix",
 
 setMethod("matrixClass", "ConstantArray", function(x) "ConstantMatrix")
 
-setMethod("DelayedArray", "ConstantArraySeed", function(seed) new_DelayedArray(seed, Class="ConstantMatrix"))
+setMethod("DelayedArray", "ConstantArraySeed", function(seed) new_DelayedArray(seed, Class="ConstantArray"))
 
 ConstantArray <- function(dim, value) {
     DelayedArray(ConstantArraySeed(dim, value))

--- a/R/ConstantArray-class.R
+++ b/R/ConstantArray-class.R
@@ -1,0 +1,17 @@
+setClass("ConstantArray",
+    contains="DelayedArray",
+    representation(seed="ConstantArraySeed")
+)
+
+setClass("ConstantMatrix",
+    contains="DelayedMatrix",
+    representation(seed="ConstantArraySeed")
+)
+
+setMethod("matrixClass", "ConstantArray", function(x) "ConstantMatrix")
+
+setMethod("DelayedArray", "ConstantArraySeed", function(seed) new_DelayedArray(seed, Class="ConstantMatrix"))
+
+ConstantArray <- function(dim, value) {
+    DelayedArray(ConstantArraySeed(dim, value))
+}

--- a/R/ConstantArray-class.R
+++ b/R/ConstantArray-class.R
@@ -3,10 +3,7 @@ setClass("ConstantArray",
     representation(seed="ConstantArraySeed")
 )
 
-setClass("ConstantMatrix",
-    contains=c("ConstantArray", "DelayedMatrix"),
-    representation(seed="ConstantArraySeed")
-)
+setClass("ConstantMatrix", contains=c("ConstantArray", "DelayedMatrix"))
 
 setMethod("matrixClass", "ConstantArray", function(x) "ConstantMatrix")
 

--- a/R/ConstantArray-class.R
+++ b/R/ConstantArray-class.R
@@ -4,7 +4,7 @@ setClass("ConstantArray",
 )
 
 setClass("ConstantMatrix",
-    contains="DelayedMatrix",
+    contains=c("ConstantArray", "DelayedMatrix"),
     representation(seed="ConstantArraySeed")
 )
 
@@ -15,3 +15,8 @@ setMethod("DelayedArray", "ConstantArraySeed", function(seed) new_DelayedArray(s
 ConstantArray <- function(dim, value) {
     DelayedArray(ConstantArraySeed(dim, value))
 }
+
+# Copied from the corresponding methods for RleArray/RleMatrix.
+setAs("ConstantArray", "ConstantMatrix", function(from) new2("ConstantMatrix", from))
+
+setAs("ConstantMatrix", "ConstantArray", function(from) from) 

--- a/R/ConstantArraySeed-class.R
+++ b/R/ConstantArraySeed-class.R
@@ -1,41 +1,28 @@
-setClass("ConstantArraySeed", slots=c(dim='integer', value="ANY"))
+setClass("ConstantArraySeed", slots=c(dim='integer', value="vector"))
 
-setValidity("ConstantArraySeed", function(object) {
-    msg <- character(0)
-
-    if (length(dim(object)) < 1 || any(dim(object) < 0)) {
-        msg <- c(msg, "'dim' must be an integer vector of length > 1 with non-negative values")
-    }
-
-    if (length(object@value) != 1 || !is.atomic(object@value)) {
-        msg <- c(msg, "'value' must be a single atomic value")
-    }
-
-    if (length(msg)) {
+setValidity2("ConstantArraySeed", function(object) {
+    msg <- validate_dim_slot(object, "dim")
+    if (!isTRUE(msg)) {
         return(msg)
+    }
+    if (length(object@value) != 1) {
+        return("'value' must be a vector of length 1")
     }
     TRUE
 })
 
-.get_constant_dim <- function(x, index) {
-    odims <- dim(x)
-    for (i in seq_along(odims)) {
-        if (!is.null(index[[i]])) {
-            odims[i] <- length(index[[i]])
-        }
-    }
-    odims
-}
-
 setMethod("extract_array", "ConstantArraySeed", function(x, index) {
-    array(x@value, .get_constant_dim(x, index))
+    array(x@value, get_Nindex_lengths(index, dim(x)))
 })
 
 setMethod("extract_sparse_array", "ConstantArraySeed", function(x, index) {
-    SparseArraySeed(.get_constant_dim(x, index), nzdata=rep(x@value, 0))
+    SparseArraySeed(get_Nindex_lengths(index, dim(x)), nzdata=rep(x@value, 0L))
 })
 
-setMethod("is_sparse", "ConstantArraySeed", function(x) isTRUE(x@value==0))
+setMethod("is_sparse", "ConstantArraySeed", function(x) {
+    zero <- vector(type(x), length=1L)
+    identical(x@value, zero)
+})
 
 ConstantArraySeed <- function(dim, value) {
     new("ConstantArraySeed", dim=as.integer(dim), value=value)

--- a/R/ConstantArraySeed-class.R
+++ b/R/ConstantArraySeed-class.R
@@ -1,0 +1,42 @@
+setClass("ConstantArraySeed", slots=c(dim='integer', value="ANY"))
+
+setValidity("ConstantArraySeed", function(object) {
+    msg <- character(0)
+
+    if (length(dim(object)) < 1 || any(dim(object) < 0)) {
+        msg <- c(msg, "'dim' must be an integer vector of length > 1 with non-negative values")
+    }
+
+    if (length(object@value) != 1 || !is.atomic(object@value)) {
+        msg <- c(msg, "'value' must be a single atomic value")
+    }
+
+    if (length(msg)) {
+        return(msg)
+    }
+    TRUE
+})
+
+.get_constant_dim <- function(x, index) {
+    odims <- dim(x)
+    for (i in seq_along(odims)) {
+        if (!is.null(index[[i]])) {
+            odims[i] <- length(index[[i]])
+        }
+    }
+    odims
+}
+
+setMethod("extract_array", "ConstantArraySeed", function(x, index) {
+    array(x@value, .get_constant_dim(x, index))
+})
+
+setMethod("extract_sparse_array", "ConstantArraySeed", function(x, index) {
+    SparseArraySeed(.get_constant_dim(x, index), nzdata=rep(x@value, 0))
+})
+
+setMethod("is_sparse", "ConstantArraySeed", function(x) isTRUE(x@value==0))
+
+ConstantArraySeed <- function(dim, value) {
+    new("ConstantArraySeed", dim=as.integer(dim), value=value)
+}

--- a/inst/unitTests/test_ConstantArray-class.R
+++ b/inst/unitTests/test_ConstantArray-class.R
@@ -1,0 +1,22 @@
+test_ConstantArray <- function()
+{
+    A1 <- ConstantArray(c(500, 200), value=1)
+    checkIdentical(as.matrix(A1), matrix(1, 500, 200))
+    checkIdentical(as.matrix(A1[1:10,]), matrix(1, 10, 200))
+    checkIdentical(as.matrix(A1[,1:10]), matrix(1, 500, 10))
+    checkIdentical(as.character(class(A1)), "ConstantMatrix")
+    checkTrue(!is_sparse(A1))
+
+    A2 <- ConstantArray(c(500, 20, 10), value=NA)
+    checkIdentical(as.array(A2), array(NA, c(500, 20, 10)))
+    checkIdentical(as.character(class(A2)), "ConstantArray")
+    checkTrue(!is_sparse(A2))
+
+    A3 <- ConstantArray(c(100, 200), value=0)
+    checkTrue(is_sparse(A3))
+    checkIdentical(as.matrix(A3), matrix(0, 100, 200))
+
+    out <- extract_sparse_array(A3, list(1:10, 1:20))
+    checkIdentical(dim(out), c(10L, 20L))
+    checkIdentical(nzdata(out), numeric(0))
+}

--- a/inst/unitTests/test_ConstantArray-class.R
+++ b/inst/unitTests/test_ConstantArray-class.R
@@ -4,7 +4,9 @@ test_ConstantArray <- function()
     checkIdentical(as.matrix(A1), matrix(1, 500, 200))
     checkIdentical(as.matrix(A1[1:10,]), matrix(1, 10, 200))
     checkIdentical(as.matrix(A1[,1:10]), matrix(1, 500, 10))
+
     checkIdentical(as.character(class(A1)), "ConstantMatrix")
+    checkTrue(is(A1, "ConstantArray"))
     checkTrue(!is_sparse(A1))
 
     A2 <- ConstantArray(c(500, 20, 10), value=NA)
@@ -19,4 +21,36 @@ test_ConstantArray <- function()
     out <- extract_sparse_array(A3, list(1:10, 1:20))
     checkIdentical(dim(out), c(10L, 20L))
     checkIdentical(nzdata(out), numeric(0))
+}
+
+test_ConstantArray_other <- function() {
+    # Testing some of the more odd types we can put in here.
+    Ac <- ConstantArray(c(500, 200), value="Aaron")
+    checkIdentical(as.matrix(Ac), matrix("Aaron", 500, 200))
+    checkTrue(!is_sparse(Ac))
+
+    Acs <- ConstantArray(c(500, 200), value="")
+    checkIdentical(as.matrix(Acs), matrix("", 500, 200))
+    checkTrue(is_sparse(Acs))
+
+    Al <- ConstantArray(c(500, 200), value=list("Aaron"))
+    checkIdentical(as.matrix(Al), matrix(list("Aaron"), 500, 200))
+
+    Al2 <- ConstantArray(c(500, 200), value=list(letters))
+    checkIdentical(as.matrix(Al2), matrix(list(letters), 500, 200))
+
+    # Checking error states.
+    checkException(ConstantArray(c(500, -1), value=0), silent=TRUE)
+    checkException(ConstantArray(c(500, 200), value=letters), silent=TRUE)
+}
+
+test_ConstantArray_coercion <- function() {
+    A1 <- ConstantArray(c(500, 200), value=1)
+    checkIdentical(A1, as(A1, "ConstantArray"))
+
+    seed <- ConstantArraySeed(c(500, 200), value=1)
+    A2 <- new("ConstantArray", seed=seed)
+    checkIdentical(as.character(class(A2)[1]), "ConstantArray")
+    A2m <- as(A2, "ConstantMatrix")
+    checkIdentical(A2m, DelayedArray(seed))
 }

--- a/man/ConstantArray-class.Rd
+++ b/man/ConstantArray-class.Rd
@@ -23,9 +23,9 @@ ConstantArray(dim, value)
 }
 
 \arguments{
-\item{dim}{Integer vector of length greater than 1, containing the dimensions of the array.}
+\item{dim}{Integer vector of length greater than or equal to 1, containing the dimensions of the array.}
 
-\item{value}{Atomic scalar containing the value to fill the matrix.}
+\item{value}{Vector of length 1, containing the value to fill the matrix.}
 
 \item{seed}{A ConstantArraySeed object.}
 }

--- a/man/ConstantArray-class.Rd
+++ b/man/ConstantArray-class.Rd
@@ -1,0 +1,52 @@
+\name{ConstantArray}
+\alias{ConstantMatrix-class}
+\alias{ConstantArray}
+\alias{ConstantArray-class}
+\alias{ConstantArraySeed-class}
+\alias{extract_array,ConstantArraySeed-method}
+\alias{extract_sparse_array,ConstantArraySeed-method}
+\alias{DelayedArray,ConstantArraySeed-method}
+\alias{ConstantArraySeed}
+
+\title{A DelayedArray subclass that contains a constant value}
+
+\description{
+A \linkS4class{DelayedArray} backend to efficiently mimic a matrix containing a constant value, without actually creating said matrix in memory.
+}
+
+\usage{
+ConstantArraySeed(dim, value)
+
+ConstantArray(dim, value)
+
+\S4method{DelayedArray}{ConstantArraySeed}(seed)
+}
+
+\arguments{
+\item{dim}{Integer vector of length greater than 1, containing the dimensions of the array.}
+
+\item{value}{Atomic scalar containing the value to fill the matrix.}
+
+\item{seed}{A ConstantArraySeed object.}
+}
+\value{
+The \code{ConstantArraySeed} constructor returns a ConstantArraySeed object.
+
+The \code{ConstantArray} and \code{DelayedArray} constructors return a ConstantArray object.
+}
+
+\details{
+This class allows us to efficiently create arrays containing a single value.
+For example, we can create matrices full of \code{NA} values, to serve as placeholders for missing assays when combining SummarizedExperiment objects.
+We use this class instead of the \linkS4class{RleArray} as the latter requires some workarounds when the product of the dimensions is greater than the maximum integer value.
+}
+
+\examples{
+# This would ordinarily take up 8 TB of memory:
+out <- ConstantArray(c(1e6, 1e6), value=NA_real_)
+out
+}
+
+\author{
+Aaron Lun
+}


### PR DESCRIPTION
Nothing too fancy here, this class just represents an array with a constant value for all of its cells.

This was originally implemented as part of **SingleCellExperiment**, which contains a primitive implementation of what I hope will be the `combineRows` implementation for `SummarizedExperiment` objects. The idea is to create all-`NA` matrices for assays that are not present in some SE objects, thus allowing them to be efficiently combined (without pretending that they're zero, which they're not). 

I thought about using an `RleArray` for this purpose but it breaks pretty quickly with:

```r
RleArray(Rle(NA, 1e10), c(1e5, 1e5))
## Error in .make_RleArraySeed_from_Rle(data, dim, dimnames, chunksize) : 
##   Input data is too long (>= 2^31). Please supply an ordinary list of Rle
##   objects instead, or an RleList object, or a DataFrame object where all
##   the columns are Rle objects.
```

I guess I could make a list of `Rle` objects, but it's a bit of a chore to have to create the chunks manually. Probably like:

```r
NR <- 1e5
NC <- 1e5
chunk.size <- floor(.Machine$integer.max/NR)
nchunks <- ceiling(NC/chunk.size)
chunks <- rep(list(Rle(NA, NR * chunk.size)), nchunks)
chunks[[nchunks]] <- Rle(NA, NR*(NC - chunk.size * (nchunks - 1)))
RleArray(chunks, c(NR, NC))
```

By comparison, the proposed class is simple to understand and use (and maintain) by just calling:

```r
ConstantArray(c(1e5, 1e5), NA)
```

Data extraction also seems faster based on some cursory timings, but this isn't a major consideration here.
