### PR TITLE
Fix sparse realization with vector arguments

### DIFF
--- a/R/DelayedUnaryIsoOpWithArgs-class.R
+++ b/R/DelayedUnaryIsoOpWithArgs-class.R
@@ -259,7 +259,13 @@ setMethod("extract_sparse_array", "DelayedUnaryIsoOpWithArgs",
         Largs <- subset_args(x@Largs, x@Lalong, index)
         Rargs <- subset_args(x@Rargs, x@Ralong, index)
 
+        ## SparseArray does not support all operations between an
+        ## SVT_SparseArray and a vector-like argument (e.g. addition with a
+        ## vector). Since 'is_sparse(x)' guarantees that the dense result is
+        ## structurally sparse, realize this block and convert it back.
+        if (length(Largs) != 0L || length(Rargs) != 0L)
+            return(as(extract_array(x, index), "SVT_SparseArray"))
+
         ans <- do.call(x@OP, c(Largs, list(svt), Rargs))
     }
 )
-

--- a/inst/unitTests/test_DelayedUnaryIsoOpWithArgs-class.R
+++ b/inst/unitTests/test_DelayedUnaryIsoOpWithArgs-class.R
@@ -89,7 +89,6 @@ test_DelayedUnaryIsoOpWithArgs_constructor <- function(silent=FALSE)
     #checkIdentical(FALSE, is_noop(x))
 }
 
-### TODO: Also test for extract_sparse_array().
 test_DelayedUnaryIsoOpWithArgs_API <- function()
 {
     ## 1. Ordinary array seed -- no-op
@@ -131,5 +130,15 @@ test_DelayedUnaryIsoOpWithArgs_API <- function()
     .basic_checks_on_DelayedOp_with_DIM3(a4, x4)
 
     checkIdentical(FALSE, is_sparse(x4))
-}
 
+    ## 5. Sparse seed with a vector-like argument
+
+    x5 <- new_DelayedUnaryIsoOpWithArgs(
+        ConstantArraySeed(c(2, 4), value=0), `+`,
+        Rargs=list(e2=c(0, 0)), Ralong=1L
+    )
+    checkTrue(is_sparse(x5))
+    a5 <- matrix(0, nrow=2, ncol=4)
+    checkIdentical(a5, as.array(x5))
+    checkIdentical(a5, as.array(as(x5, "SVT_SparseArray")))
+}


### PR DESCRIPTION
## Summary
Fix realization of structurally sparse delayed operations with vector-like arguments.

## Thanks to maintainers
Thanks to the DelayedArray and SparseArray maintainers for maintaining these sparse realization interfaces.

## Issue or motivation
Closes #123. Adding a zero vector to a zero-valued ConstantArray is structurally sparse, but realization currently fails.

## Root cause
`is_sparse()` identifies the zero-preserving operation, while `extract_sparse_array()` passes the sparse block and vector directly to SparseArray. SparseArray does not support this `+` operation between a sparse object and a vector.

## Change
When vector-like arguments are present, evaluate the block through `extract_array()` and convert the result back to `SVT_SparseArray`. The no-argument sparse fast path is unchanged. A regression test covers the ConstantArray case.

## Tests
- Full DelayedArray RUnit suite: 43 test functions, 0 errors, 0 failures.
- HDF5Array reproduction using `writeHDF5Array()`: passed.
- `R CMD build .`: passed, including all three vignettes.
- `R CMD check --no-manual --no-vignettes`: passed with 1 WARNING and 2 NOTEs.

## Scope
This does not change dense extraction, the existing no-argument sparse path, or the SparseArray API.